### PR TITLE
docs(registry): reconcile roadmap with actually-shipped components (kbd/input-group not shipped)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,6 @@ registry/
     ├── breadcrumb/    (breadcrumb.tsx + breadcrumb.css)
     ├── card/          (card.tsx + card.css)
     ├── field/         (field.tsx + field.css)
-    ├── input-group/   (input-group.tsx + input-group.css)
-    ├── kbd/           (kbd.tsx + kbd.css)
     ├── popover/       (popover.tsx + popover.css)
     ├── separator/     (separator.tsx + separator.css)
     ├── sheet/         (sheet.tsx + sheet.css)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,13 +13,20 @@ Button, Badge, Tag, Tooltip, Toast, Menu, Checkbox, Radio, Toggle, Banner Info, 
 
 ---
 
-## v1.1 Aube (12 composants) — Shipped
+## v1.1 Aube (10 composants) — Shipped
 
 La lumiere apparait. Foundation, overlays, data display, navigation.
 
-Alert, Alert Dialog, Breadcrumb, Card, Field, Input Group, Kbd, Popover, Separator, Skeleton, Stepper, Table
+Alert, Alert Dialog, Breadcrumb, Card, Field, Popover, Separator, Skeleton, Stepper, Table
 
-**Total shipped : 35 composants**
+**Total shipped : 33 composants**
+
+`Input Group` and `Kbd` were scoped for v1.1 but never shipped — no `.tsx`, no `registry.json` entry, not served at `ui.getlyse.com`. Only a `doc.md` design-notes stub exists for each under `registry/new-york/ui/`.
+
+| Composant | Statut | Note |
+|-----------|--------|------|
+| Kbd | To do | Design notes only (`doc.md`), no implementation started |
+| Input Group | Dropped | Wrong approach (wrapper breaks `Field` a11y) — see `specs/dropped/input-group-spec.md`. Superseded by extending `Input` with addon props. |
 
 ---
 


### PR DESCRIPTION
## What

`docs/roadmap.md` and `CLAUDE.md` claimed `Kbd` and `Input Group` shipped in v1.1 (12 composants / total 35). Both are `doc.md`-only stubs: no `.tsx`, no `registry.json` entry, not served at `ui.getlyse.com`. Corrected v1.1 to 10 composants (total 33) and removed the two from `CLAUDE.md`'s registry file tree, which listed non-existent `input-group.tsx/css` and `kbd.tsx/css`.

## Why

Docs claiming shipped components that don't build/serve is misleading to consumers of the registry. `Kbd` is genuinely "to do" (no implementation started); `Input Group` was actively dropped 2026-03-14 (see `specs/dropped/input-group-spec.md` — wrapper approach breaks `Field` a11y, superseded by extending `Input` with addon props). `docs/roadmap.md` now reflects both statuses honestly instead of "Shipped."

## Test plan

- [x] Verified: `registry/new-york/ui/{kbd,input-group}/` contain only `doc.md`, no `.tsx`
- [x] Verified: `registry.json` has no `kbd` or `input-group` entries
- [x] Verified: `public/r/` has no `kbd.json` / `input-group.json`, `lib/navigation.ts` and `app/components/directory/page.tsx` have no dangling references (nothing live/broken)
- [x] Cross-checked the corrected count (33 shipped through v1.1) against the filesystem: 38 total `.tsx` components repo-wide (v1.0: 23 + v1.1: 10 + v1.2 shipped: 5), matching README's existing "38 components" claim
- N/A `pnpm build` / `pnpm lint` — docs-only change, no source touched
- N/A registry/doc-page checklist items — no component added

## Also found (not fixed here — owner cleanup)

- 10 stale remote branches with no open PR: `feat/batch-1-foundation`, `feat/batch-2-forms`, `feat/batch-3-overlays`, `feat/collapsible-component`, `feat/component-accordion`, `feat/component-sheet`, `feat/pagination`, `feat/slider`, `feat/token-reference-page`, `migrate-base-ui`
- The `v1.1.0 — Aube` release (tagged 2026-03-15, currently "Latest") predates this correction and may want a note or re-tag